### PR TITLE
Fix YAML parsing errors in 2 chapters

### DIFF
--- a/_es/decide.md
+++ b/_es/decide.md
@@ -1,7 +1,7 @@
 ---
 part: one
 title: Toma decisiones más inteligentes
-subtitle: "Decide más rápido, pero tómate el tiempo suficiente para hacer bien las cosas".
+subtitle: "Decide más rápido, pero tómate el tiempo suficiente para hacer bien las cosas."
 ---
 
 * TOC

--- a/_es/lean.md
+++ b/_es/lean.md
@@ -1,7 +1,7 @@
 ---
 part: one
 title: Elimina pérdidas de tiempo
-subtitle: "Practica el enfoque "lean" mediante la mejora constante de la forma de hacer las cosas."
+subtitle: "Practica el enfoque \"lean\" mediante la mejora constante de la forma de hacer las cosas."
 ---
 
 * TOC


### PR DESCRIPTION
The YAML page header contained invalid syntax (unescaped quotes and a dot outside of quotes), which caused errors when parsing it and prevented the page header from being correctly generated.

## Comparison

### Lean
https://nooffice.org/es/lean/

<details>

Original:
![image](https://user-images.githubusercontent.com/889383/115140465-bf6a6b00-a037-11eb-827e-f5bace97bb77.png)

Fixed:
![image](https://user-images.githubusercontent.com/889383/115140489-db6e0c80-a037-11eb-973c-dd487c7f5f44.png)
</details>


### Decide
https://nooffice.org/es/decide/

<details>

Original:
![image](https://user-images.githubusercontent.com/889383/115140497-e2951a80-a037-11eb-8b09-f9c67d064819.png)


Fixed:
![image](https://user-images.githubusercontent.com/889383/115140474-c6917900-a037-11eb-8ab0-f077e097138e.png)
</details>